### PR TITLE
Make Instructors singular

### DIFF
--- a/_includes/workshop_ad.html
+++ b/_includes/workshop_ad.html
@@ -30,7 +30,7 @@
         </div>
         <div class="col-md-6">
           <p>
-          <strong>Instructors:</strong>
+          <strong>Instructor:</strong>
           {% if page.instructor %}
           {{page.instructor | join: ', ' %}}
           {% else %}


### PR DESCRIPTION
Extensive edits to the word Instructors. This PR is brought to you by the letter "S".